### PR TITLE
Revise software name in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ MIT License
 Copyright (c) 2026 Adithya Balan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
+of this software and associated documentation files (the DevWatch), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is


### PR DESCRIPTION
Updated the name of the software in the license from 'Software' to 'DevWatch'.