### PR TITLE
Enhance build section styles and improve empty state handling

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -447,40 +447,46 @@
 
 /* ── Build section ─────────────────────────────────────────────────────────── */
 .dw-build-active-card {
-    background-color: rgba(120, 174, 237, 0.08);
-    border: 1px solid rgba(120, 174, 237, 0.15);
-    border-radius: 8px;
-    padding: 8px 12px;
-    margin-bottom: 6px;
+    background-color: rgba(120, 174, 237, 0.10);
+    border: 1px solid rgba(120, 174, 237, 0.22);
+    border-radius: 10px;
+    padding: 8px 11px;
+    margin-bottom: 7px;
     margin-left: 12px;
     margin-right: 12px;
 }
-.dw-build-active-icon { color: #78aeed; font-size: 14px; y-align: center; }
-.dw-build-status      { font-size: 13px; font-weight: 600; color: #eeeeee; y-align: center; }
-.dw-build-meta        { font-size: 11px; color: #888888; y-align: center; padding-top: 2px; }
+.dw-build-active-row { spacing: 8px; y-align: center; }
+.dw-build-active-icon { color: #8cc0ff; icon-size: 13px; margin-right: 5px; y-align: center; }
+.dw-build-active-text { spacing: 2px; }
+.dw-build-status      { font-size: 13px; font-weight: 700; color: #f4f4f4; y-align: center; }
+.dw-build-meta        { font-size: 10px; color: rgba(232, 232, 232, 0.70); y-align: center; padding-top: 0; }
+.dw-build-empty       { font-size: 11px; color: rgba(240, 240, 240, 0.58); padding: 2px 0; }
 
 /* History sub-menu item tweaks */
 .devwatch-menu .popup-sub-menu .dw-build-hist-row {
     padding-top: 2px;
     padding-bottom: 2px;
+    margin-left: 12px;
     margin-right: 12px;
 }
-.dw-build-ok-icon     { color: #57e389; icon-size: 14px; margin-right: 8px; }
-.dw-build-fail-icon   { color: #ed333b; icon-size: 14px; margin-right: 8px; }
-.dw-build-proj-name   { font-size: 12px; font-weight: 500; color: #cccccc; x-expand: true; y-align: center; }
+.dw-build-ok-icon     { color: #57e389; icon-size: 11px; margin-right: 7px; }
+.dw-build-fail-icon   { color: #ed333b; icon-size: 11px; margin-right: 7px; }
+.dw-build-proj-name   { font-size: 12px; font-weight: 500; color: rgba(235, 235, 235, 0.88); x-expand: true; y-align: center; }
+
+.dw-build-stats-row   { spacing: 6px; y-align: center; }
 
 .dw-build-stat-pill {
-    background-color: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.04);
+    background-color: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 6px;
-    padding: 2px 8px;
-    font-size: 10px;
-    color: #aaaaaa;
+    padding: 1px 7px;
+    font-size: 9px;
+    color: rgba(228, 228, 228, 0.78);
     y-align: center;
     font-family: monospace;
 }
 
-.dw-build-hist-hdr    { font-size: 12px; color: #dddddd; font-weight: 600; padding-top: 10px;
+.dw-build-hist-hdr    { font-size: 11px; color: #dddddd; font-weight: 600; padding-top: 8px;
     padding-bottom: 4px; }
 
 /* ── Process sub-rows ──────────────────────────────────────────────────────── */
@@ -651,7 +657,7 @@
     min-height: 26px;
 }
 .dw-build-active-card, .dw-session-card, .dw-session-card-primary {
-    min-height: 48px;
+    min-height: 44px;
 }
 
-.dw-build-hist-row { min-height: 28px; }
+.dw-build-hist-row { min-height: 26px; }

--- a/ui/perfSection.js
+++ b/ui/perfSection.js
@@ -50,7 +50,7 @@ export function buildPerfSection(menu, buildResult, maxRows = DEFAULT_MAX_HISTOR
     // ── Active builds ──────────────────────────────────────────────────────
     if (active.length === 0) {
         const emptyActive = new PopupMenu.PopupMenuItem(_('  No active builds'), { reactive: false });
-        emptyActive.label.style_class = 'dw-dim';
+        emptyActive.label.style_class = 'dw-dim dw-build-empty';
         emptyActive._devwatchSection = SECTION_TAG;
         menu.addMenuItem(emptyActive);
     } else {
@@ -96,6 +96,7 @@ function _buildActiveRow(run) {
     item.add_style_class_name('dw-build-active-card');
 
     const row  = new St.BoxLayout({ x_expand: true, y_align: Clutter.ActorAlign.CENTER});
+    row.add_style_class_name('dw-build-active-row');
     row.spacing = 10;
 
     row.add_child(new St.Icon({
@@ -105,6 +106,7 @@ function _buildActiveRow(run) {
     }));
     
     const textStack = new St.BoxLayout({ vertical: true, x_expand: true, y_align: Clutter.ActorAlign.CENTER });
+    textStack.add_style_class_name('dw-build-active-text');
 
     // "Building tracktite" — project name is the primary label
     const proj = run.projectRoot
@@ -163,6 +165,7 @@ function _buildHistoryRow(run) {
     
     // Right-aligned stats
     const statsBox = new St.BoxLayout({ y_align: Clutter.ActorAlign.CENTER });
+    statsBox.add_style_class_name('dw-build-stats-row');
     statsBox.spacing = 6;
 
     statsBox.add_child(new St.Label({


### PR DESCRIPTION
This pull request makes a series of visual and structural improvements to the build section in both the CSS and UI JavaScript. The main focus is on refining the appearance and spacing of build cards, rows, and status indicators for a cleaner and more consistent user interface. Several new CSS classes are introduced and applied in the JavaScript to better organize component styling.

**Styling and layout improvements:**

* Updated `.dw-build-active-card`, `.dw-build-hist-row`, and related CSS classes for improved colors, border radii, padding, font weights, and spacing, resulting in a cleaner and more modern look for build cards and rows. [[1]](diffhunk://#diff-eccba86bec96366b744e5b2d8fa589424bf024843666c7009a104b1dcc610127L450-R489) [[2]](diffhunk://#diff-eccba86bec96366b744e5b2d8fa589424bf024843666c7009a104b1dcc610127L654-R663)
* Introduced new CSS classes such as `.dw-build-active-row`, `.dw-build-active-text`, `.dw-build-stats-row`, and `.dw-build-empty` to provide more granular control over layout and appearance of active and history build rows.

**JavaScript UI updates:**

* Applied the new `.dw-build-empty` style to the "No active builds" message for consistent styling with the rest of the UI.
* Added `.dw-build-active-row` and `.dw-build-active-text` classes to the respective layout containers in the active build row for improved alignment and spacing. [[1]](diffhunk://#diff-2a918e49fcb64aff9358d09df84f2d2783fb0144dc4c84c182e54e05a5a0c554R99) [[2]](diffhunk://#diff-2a918e49fcb64aff9358d09df84f2d2783fb0144dc4c84c182e54e05a5a0c554R109)
* Added `.dw-build-stats-row` class to the stats container in the build history row for better spacing and alignment of build statistics.