### PR TITLE
Add panel placement and index settings for extension positioning

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -88,6 +88,14 @@ export default class DevWatchExtension extends Extension {
                 this._focusTracker?.setPollIntervalSeconds?.(this._settings.get_int('poll-interval'));
             }
         );
+          this._panelPositionChangedId = this._settings.connect(
+              'changed::panel-position',
+              () => this._applyPanelPlacement()
+          );
+          this._panelIndexChangedId = this._settings.connect(
+              'changed::panel-index',
+              () => this._applyPanelPlacement()
+          );
 
         /** Cached from last _refresh() — used by Save Now button. */
         this._lastProjectMap  = null;
@@ -181,7 +189,12 @@ export default class DevWatchExtension extends Extension {
         );
 
         // ── Add to panel ───────────────────────────────────────────────
-        Main.panel.addToStatusArea(this.uuid, this._indicator, 0, 'right');
+          Main.panel.addToStatusArea(
+              this.uuid,
+              this._indicator,
+              this._getPanelIndex(),
+              this._getPanelPosition()
+          );
 
         // ── Apply panel menu min-width ─────────────────────────────────
         this._indicator.menu.box.add_style_class_name('devwatch-menu');
@@ -264,6 +277,14 @@ export default class DevWatchExtension extends Extension {
             this._settings?.disconnect(this._settingsChangedId);
             this._settingsChangedId = null;
         }
+          if (this._panelPositionChangedId !== null && this._panelPositionChangedId !== undefined) {
+              this._settings?.disconnect(this._panelPositionChangedId);
+              this._panelPositionChangedId = null;
+          }
+          if (this._panelIndexChangedId !== null && this._panelIndexChangedId !== undefined) {
+              this._settings?.disconnect(this._panelIndexChangedId);
+              this._panelIndexChangedId = null;
+          }
         this._settings = null;
 
         // Cancel all in-flight async operations
@@ -432,6 +453,46 @@ export default class DevWatchExtension extends Extension {
             }
         );
         console.log('[DevWatch] Poll interval changed to', interval, 's');
+    }
+
+    _getPanelPosition() {
+        const value = this._settings?.get_string('panel-position') ?? 'right';
+        if (value === 'left' || value === 'center' || value === 'right')
+            return value;
+        return 'right';
+    }
+
+    _getPanelIndex() {
+        const value = this._settings?.get_int('panel-index') ?? 0;
+        return Math.max(0, Math.min(30, value));
+    }
+
+    _getPanelBox(position) {
+        if (position === 'left')
+            return Main.panel._leftBox;
+        if (position === 'center')
+            return Main.panel._centerBox;
+        return Main.panel._rightBox;
+    }
+
+    _applyPanelPlacement() {
+        if (!this._indicator?.container)
+            return;
+
+        const position = this._getPanelPosition();
+        const index = this._getPanelIndex();
+        const targetBox = this._getPanelBox(position);
+        if (!targetBox)
+            return;
+
+        const container = this._indicator.container;
+        const parent = container.get_parent();
+        if (parent)
+            parent.remove_child(container);
+
+        const children = targetBox.get_children();
+        const insertAt = Math.max(0, Math.min(index, children.length));
+        targetBox.insert_child_at_index(container, insertAt);
     }
 
     /**

--- a/prefs.js
+++ b/prefs.js
@@ -52,6 +52,57 @@ export default class DevWatchPreferences extends ExtensionPreferences {
         settings.bind('poll-interval', pollRow, 'value', 0);
         generalGroup.add(pollRow);
 
+          const placementGroup = new Adw.PreferencesGroup({
+              title: _('Panel Placement'),
+              description: _('Choose where DevWatch appears in the GNOME top bar and its order index.'),
+          });
+          generalPage.add(placementGroup);
+
+          const positionModel = Gtk.StringList.new([
+              _('Left'),
+              _('Center'),
+              _('Right'),
+          ]);
+
+          const positionRow = new Adw.ComboRow({
+              title: _('Panel position'),
+              subtitle: _('Select the top bar area where DevWatch is placed'),
+              model: positionModel,
+          });
+
+          const positionValues = ['left', 'center', 'right'];
+          const currentPosition = settings.get_string('panel-position');
+          const currentPosIndex = Math.max(0, positionValues.indexOf(currentPosition));
+          positionRow.set_selected(currentPosIndex);
+
+          positionRow.connect('notify::selected', () => {
+              const idx = positionRow.get_selected();
+              const value = positionValues[idx] ?? 'right';
+              settings.set_string('panel-position', value);
+          });
+
+          settings.connect('changed::panel-position', () => {
+              const value = settings.get_string('panel-position');
+              const idx = Math.max(0, positionValues.indexOf(value));
+              if (positionRow.get_selected() !== idx)
+                  positionRow.set_selected(idx);
+          });
+
+          placementGroup.add(positionRow);
+
+          const panelIndexRow = new Adw.SpinRow({
+              title: _('Panel index'),
+              subtitle: _('Order inside selected panel area (0 – 30)'),
+              adjustment: new Gtk.Adjustment({
+                  lower: 0,
+                  upper: 30,
+                  step_increment: 1,
+                  page_increment: 5,
+              }),
+          });
+          settings.bind('panel-index', panelIndexRow, 'value', 0);
+          placementGroup.add(panelIndexRow);
+
         // ── Page: Ports ────────────────────────────────────────────────────
         const portsPage = new Adw.PreferencesPage({
             title: _('Ports'),

--- a/schemas/org.gnome.shell.extensions.devwatch.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.devwatch.gschema.xml
@@ -15,6 +15,26 @@
       <range min="5" max="60"/>
     </key>
 
+      <!-- ── Panel placement ─────────────────────────────────────────────── -->
+      <key name="panel-position" type="s">
+        <default>'right'</default>
+        <summary>Panel box placement</summary>
+        <description>
+          Choose where DevWatch appears in the GNOME top bar.
+          Allowed values: left, center, right.
+        </description>
+      </key>
+
+      <key name="panel-index" type="i">
+        <default>0</default>
+        <summary>Panel order index</summary>
+        <description>
+          Position index inside the selected panel box.
+          Lower numbers place DevWatch closer to the start of that box.
+        </description>
+        <range min="0" max="30"/>
+      </key>
+
     <!-- ── Port monitoring ────────────────────────────────────────────── -->
     <key name="show-system-ports" type="b">
       <default>false</default>


### PR DESCRIPTION
This pull request adds support for customizing the placement of the DevWatch extension in the GNOME top bar. Users can now select both the panel area (left, center, or right) and the order index within that area from the preferences UI. The extension responds dynamically to changes in these settings, updating its position without requiring a restart.

**Panel placement customization:**

* Added new settings `panel-position` (string: left, center, right) and `panel-index` (integer: 0–30) to the schema for controlling DevWatch's placement in the top bar.
* Updated the preferences UI in `prefs.js` to provide controls for selecting the panel area and index, including a combo row for position and a spin row for index. These controls are bound to the new settings and kept in sync.

**Extension logic updates:**

* Modified the extension initialization in `extension.js` to read the new placement settings and pass them to `Main.panel.addToStatusArea`, ensuring DevWatch is placed according to user preferences.
* Added listeners for changes to `panel-position` and `panel-index` settings, triggering a new `_applyPanelPlacement` method that moves the indicator to the correct location in real time. [[1]](diffhunk://#diff-19a9a3efb94bf1b84229bda71ab0ef5badcdbf34ba3a0c9e4152a82c569a21e6R91-R98) [[2]](diffhunk://#diff-19a9a3efb94bf1b84229bda71ab0ef5badcdbf34ba3a0c9e4152a82c569a21e6R458-R497)
* Ensured proper cleanup by disconnecting the new settings listeners during extension disable/unload.